### PR TITLE
Fix bug that merging maps did not check for null

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.citrine</groupId>
     <artifactId>jpif</artifactId>
-    <version>2.1.8</version>
+    <version>2.1.9</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/io/citrine/jpif/obj/merge/MergeStrategy.java
+++ b/src/main/java/io/citrine/jpif/obj/merge/MergeStrategy.java
@@ -20,11 +20,9 @@ public enum MergeStrategy {
         @Override
         public List<Object> merge(List<Object> mergeInto, List<Object> mergeFrom) {
             List<Object> result = new ArrayList<>();
-
             if (mergeInto != null) {
                 result.addAll(mergeInto);
             }
-
             if (mergeFrom != null) {
                 result.addAll(mergeFrom);
             }
@@ -42,8 +40,12 @@ public enum MergeStrategy {
         @Override
         public Map<String, Object> merge(Map<String, Object> mergeInto, Map<String, Object> mergeFrom) {
             Map<String, Object> result = new HashMap<>();
-            result.putAll(mergeInto);
-            result.putAll(mergeFrom);
+            if (mergeInto != null) {
+                result.putAll(mergeInto);
+            }
+            if (mergeFrom != null) {
+                result.putAll(mergeFrom);
+            }
             return result;
         }
 

--- a/src/main/java/io/citrine/jpif/obj/merge/PioReflection.java
+++ b/src/main/java/io/citrine/jpif/obj/merge/PioReflection.java
@@ -63,16 +63,6 @@ public class PioReflection {
     }
 
     /**
-     * Check whether a particular Method discovered through reflection is a getter with a List type.
-     *
-     * @param method the method to check.
-     * @return true if the Method has a return type of List.
-     */
-    public boolean isList(Method method) {
-        return method.getReturnType().getCanonicalName().equals("java.util.List");
-    }
-
-    /**
      * Check whether a particular Method name discovered through reflection is a getter with a List type.
      *
      * @param method the name of the method to check.


### PR DESCRIPTION
In cases that a map was being merged, null values were not checked for. This also removes a method that was not being used and should not have been used.