### PR TITLE
2.3.0: Add serializable to objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.citrine</groupId>
     <artifactId>jpif</artifactId>
-    <version>2.2.0</version>
+    <version>2.3.0</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -43,22 +43,22 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.7.1</version>
+            <version>2.8.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.7.1</version>
+            <version>2.8.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.7.1</version>
+            <version>2.8.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-jsonSchema</artifactId>
-            <version>2.7.1</version>
+            <version>2.8.7</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>
@@ -69,6 +69,13 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/io/citrine/jpif/obj/common/Classification.java
+++ b/src/main/java/io/citrine/jpif/obj/common/Classification.java
@@ -8,8 +8,13 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import io.citrine.jpif.util.PifObjectMapper;
+import io.citrine.jpif.util.PifSerializationUtil;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 
 /**
  * Information about a generic classification.
@@ -23,7 +28,7 @@ import java.io.IOException;
  *
  * @author Kyle Michel
  */
-public class Classification extends Pio {
+public class Classification extends Pio implements Serializable {
 
     /**
      * Set the name of the classification.
@@ -114,6 +119,36 @@ public class Classification extends Pio {
                 ? null
                 : new Classification().setValue(input.toString());
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = -492066291787497168L;
 
     /** Name of the classification. */
     private String name;

--- a/src/main/java/io/citrine/jpif/obj/common/DisplayItem.java
+++ b/src/main/java/io/citrine/jpif/obj/common/DisplayItem.java
@@ -3,6 +3,13 @@ package io.citrine.jpif.obj.common;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import io.citrine.jpif.util.PifSerializationUtil;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 
 /**
  * Representation of a display item (table or figure)
@@ -17,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
  *
  * @author Kyle Michel
  */
-public class DisplayItem extends Pio {
+public class DisplayItem extends Pio implements Serializable {
 
     /**
      * Set the number of the display item.
@@ -103,6 +110,36 @@ public class DisplayItem extends Pio {
         super.addUnsupportedField(key, value);
         return this;
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = 1300648955622155072L;
 
     /** Figure or table number. */
     private String number;

--- a/src/main/java/io/citrine/jpif/obj/common/FileReference.java
+++ b/src/main/java/io/citrine/jpif/obj/common/FileReference.java
@@ -8,8 +8,13 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import io.citrine.jpif.util.PifObjectMapper;
+import io.citrine.jpif.util.PifSerializationUtil;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 
 /**
  * Information about a file.
@@ -25,7 +30,7 @@ import java.io.IOException;
  *
  * @author Kyle Michel
  */
-public class FileReference extends Pio {
+public class FileReference extends Pio implements Serializable {
 
     /**
      * Set the relative path of the file.
@@ -146,6 +151,36 @@ public class FileReference extends Pio {
         super.addUnsupportedField(key, value);
         return this;
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = 2550510340810945282L;
 
     /** String with the relative path of the file. */
     private String relativePath;

--- a/src/main/java/io/citrine/jpif/obj/common/Id.java
+++ b/src/main/java/io/citrine/jpif/obj/common/Id.java
@@ -8,8 +8,13 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import io.citrine.jpif.util.PifObjectMapper;
+import io.citrine.jpif.util.PifSerializationUtil;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 
 /**
  * Information about a generic identifier.
@@ -23,7 +28,7 @@ import java.io.IOException;
  *
  * @author Kyle Michel
  */
-public class Id extends Pio {
+public class Id extends Pio implements Serializable {
 
     /**
      * Set the name of the identifier.
@@ -113,6 +118,36 @@ public class Id extends Pio {
                 ? null
                 : new Id().setValue(input.toString());
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = 6536471749646038577L;
 
     /** Name of the identifier. */
     private String name;

--- a/src/main/java/io/citrine/jpif/obj/common/Instrument.java
+++ b/src/main/java/io/citrine/jpif/obj/common/Instrument.java
@@ -3,6 +3,13 @@ package io.citrine.jpif.obj.common;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import io.citrine.jpif.util.PifSerializationUtil;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 
 /**
  * Description of an instrument used in an experimental measurement.
@@ -18,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
  *
  * @author Kyle Michel
  */
-public class Instrument extends Pio {
+public class Instrument extends Pio implements Serializable {
 
     /**
      * Set the name of the instrument.
@@ -126,6 +133,36 @@ public class Instrument extends Pio {
         super.addUnsupportedField(key, value);
         return this;
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = -8087377907149738714L;
 
     /** Name of the instrument. */
     private String name;

--- a/src/main/java/io/citrine/jpif/obj/common/License.java
+++ b/src/main/java/io/citrine/jpif/obj/common/License.java
@@ -8,8 +8,13 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import io.citrine.jpif.util.PifObjectMapper;
+import io.citrine.jpif.util.PifSerializationUtil;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URL;
 
@@ -26,7 +31,7 @@ import java.net.URL;
  *
  * @author Kyle Michel
  */
-public class License extends Pio {
+public class License extends Pio implements Serializable {
 
     /**
      * Set the name of the license.
@@ -163,6 +168,36 @@ public class License extends Pio {
             return false;
         }
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = -409398361626668427L;
 
     /** Name of the license. */
     private String name;

--- a/src/main/java/io/citrine/jpif/obj/common/Method.java
+++ b/src/main/java/io/citrine/jpif/obj/common/Method.java
@@ -9,8 +9,13 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import io.citrine.jpif.util.PifObjectMapper;
+import io.citrine.jpif.util.PifSerializationUtil;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -28,7 +33,7 @@ import java.util.List;
  *
  * @author Kyle Michel
  */
-public class Method extends Pio {
+public class Method extends Pio implements Serializable {
 
     /**
      * Set the name of the method.
@@ -286,6 +291,36 @@ public class Method extends Pio {
     public static Method valueOf(final String name) {
         return new Method().setName(name);
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = -8433357173522535611L;
 
     /** Name of the measurement method. */
     private String name;

--- a/src/main/java/io/citrine/jpif/obj/common/Name.java
+++ b/src/main/java/io/citrine/jpif/obj/common/Name.java
@@ -8,8 +8,13 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import io.citrine.jpif.util.PifObjectMapper;
+import io.citrine.jpif.util.PifSerializationUtil;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -27,7 +32,7 @@ import java.util.regex.Pattern;
  *
  * @author Kyle Michel
  */
-public class Name extends Pio {
+public class Name extends Pio implements Serializable {
 
     /**
      * Set the title of the person.
@@ -308,6 +313,36 @@ public class Name extends Pio {
         }
         return res.toString();
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = -3776503025909792845L;
 
     /** Title of the person. */
     private String title;

--- a/src/main/java/io/citrine/jpif/obj/common/Pages.java
+++ b/src/main/java/io/citrine/jpif/obj/common/Pages.java
@@ -8,8 +8,13 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import io.citrine.jpif.util.PifObjectMapper;
+import io.citrine.jpif.util.PifSerializationUtil;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.util.regex.Pattern;
 
 /**
@@ -24,7 +29,7 @@ import java.util.regex.Pattern;
  *
  * @author Kyle Michel
  */
-public class Pages extends Pio {
+public class Pages extends Pio implements Serializable {
 
     /**
      * Set the starting page.
@@ -132,6 +137,36 @@ public class Pages extends Pio {
         }
         return res;
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = -7604544603018821739L;
 
     /** Starting page. */
     private String start;

--- a/src/main/java/io/citrine/jpif/obj/common/Person.java
+++ b/src/main/java/io/citrine/jpif/obj/common/Person.java
@@ -10,9 +10,14 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.citrine.jpif.util.Orcid;
 import io.citrine.jpif.util.PifObjectMapper;
+import io.citrine.jpif.util.PifSerializationUtil;
 import org.apache.commons.validator.routines.EmailValidator;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 
 /**
  * Information about a person.
@@ -28,7 +33,7 @@ import java.io.IOException;
  *
  * @author Kyle Michel
  */
-public class Person extends Pio {
+public class Person extends Pio implements Serializable {
 
     /**
      * Set the name of the person.
@@ -192,6 +197,36 @@ public class Person extends Pio {
         input = input.trim();
         return Orcid.isValid(input);
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = 6898080417547546195L;
 
     /** Name of the person. */
     private Name name;

--- a/src/main/java/io/citrine/jpif/obj/common/Pio.java
+++ b/src/main/java/io/citrine/jpif/obj/common/Pio.java
@@ -8,7 +8,13 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import io.citrine.jpif.obj.merge.MergeStrategy;
 import io.citrine.jpif.obj.merge.PioReflection;
 import io.citrine.jpif.util.PifObjectMapper;
+import io.citrine.jpif.util.PifSerializationUtil;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,7 +29,7 @@ import java.util.Map;
  * @author Kyle Michel
  * @author Sean Paradiso
  */
-public abstract class Pio {
+public abstract class Pio implements Serializable {
 
     /**
      * Set the tags for this object.
@@ -299,9 +305,7 @@ public abstract class Pio {
                 .forEach(getter -> {
                     try {
                         mergeResult.merge(reflection, getter, mergeFrom, strategy);
-                    } catch (InvocationTargetException e) {
-                        e.printStackTrace();
-                    } catch (IllegalAccessException e) {
+                    } catch (InvocationTargetException | IllegalAccessException e) {
                         e.printStackTrace();
                     }
                 });
@@ -310,12 +314,38 @@ public abstract class Pio {
     }
 
     /**
-     * List of tags for the object.
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
      */
-    private List<String> tags;
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
 
     /**
-     * Map of unsupported field names to their values.
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
      */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = 8298361482995229987L;
+
+    /** List of tags for the object. */
+    private List<String> tags;
+
+    /** Map of unsupported field names to their values. */
     private Map<String, Object> unsupportedFields;
 }

--- a/src/main/java/io/citrine/jpif/obj/common/ProcessStep.java
+++ b/src/main/java/io/citrine/jpif/obj/common/ProcessStep.java
@@ -4,7 +4,13 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import io.citrine.jpif.util.PifSerializationUtil;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -23,7 +29,7 @@ import java.util.List;
  *
  * @author Kyle Michel
  */
-public class ProcessStep extends Pio {
+public class ProcessStep extends Pio implements Serializable {
 
     /**
      * Set the name of this process step.
@@ -374,6 +380,36 @@ public class ProcessStep extends Pio {
         super.addUnsupportedField(key, value);
         return this;
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = 802890674943344344L;
 
     /** Name of the process step. */
     private String name;

--- a/src/main/java/io/citrine/jpif/obj/common/Property.java
+++ b/src/main/java/io/citrine/jpif/obj/common/Property.java
@@ -7,7 +7,13 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.citrine.jpif.util.PifSerializationUtil;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -36,7 +42,7 @@ import java.util.Map;
  *
  * @author Kyle Michel
  */
-public class Property extends Value {
+public class Property extends Value implements Serializable {
     // Since java does not allow for multiple inheritance, this class encapsulates an {@link Rcl} object that
     // adds support for reference, contact, and license information.
 
@@ -731,6 +737,36 @@ public class Property extends Value {
         super.addUnsupportedField(key, value);
         return this;
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = 8475222427656448646L;
 
     /** List of conditions for the property. */
     private List<Value> conditions;

--- a/src/main/java/io/citrine/jpif/obj/common/Quantity.java
+++ b/src/main/java/io/citrine/jpif/obj/common/Quantity.java
@@ -5,6 +5,13 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.citrine.jpif.util.PifSerializationUtil;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 
 /**
  * Information about the quantity of a system. The fields ending with massPercent, volumePercent, and 
@@ -23,7 +30,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  *
  * @author Kyle Michel
  */
-public class Quantity extends Pio {
+public class Quantity extends Pio implements Serializable {
 
     /**
      * Set the actual percent of the total mass made up by this system.
@@ -313,6 +320,36 @@ public class Quantity extends Pio {
         super.addUnsupportedField(key, value);
         return this;
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = -9159460660195114348L;
 
     /** Actual percent of the total mass. */
     private Scalar actualMassPercent;

--- a/src/main/java/io/citrine/jpif/obj/common/Rcl.java
+++ b/src/main/java/io/citrine/jpif/obj/common/Rcl.java
@@ -5,7 +5,13 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.citrine.jpif.util.PifSerializationUtil;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -15,7 +21,7 @@ import java.util.List;
  *
  * @author Kyle Michel
  */
-public class Rcl extends Pio {
+public class Rcl extends Pio implements Serializable {
 
     /**
      * Set the list of references where information about this item is published.
@@ -349,6 +355,36 @@ public class Rcl extends Pio {
         super.addUnsupportedField(key, value);
         return this;
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = -1800044862464093051L;
 
     /** List of references for the item. */
     private List<Reference> references;

--- a/src/main/java/io/citrine/jpif/obj/common/Reference.java
+++ b/src/main/java/io/citrine/jpif/obj/common/Reference.java
@@ -5,7 +5,13 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.citrine.jpif.util.PifSerializationUtil;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -38,7 +44,7 @@ import java.util.List;
  *
  * @author Kyle Michel
  */
-public class Reference extends Pio {
+public class Reference extends Pio implements Serializable {
 
     /**
      * Set the DOI of the published work.
@@ -862,6 +868,36 @@ public class Reference extends Pio {
         super.addUnsupportedField(key, value);
         return this;
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = 7973360547293231280L;
 
     /** DOI of the published work. */
     private String doi;

--- a/src/main/java/io/citrine/jpif/obj/common/Scalar.java
+++ b/src/main/java/io/citrine/jpif/obj/common/Scalar.java
@@ -8,8 +8,13 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import io.citrine.jpif.util.PifObjectMapper;
+import io.citrine.jpif.util.PifSerializationUtil;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -32,7 +37,7 @@ import java.util.regex.Pattern;
  *
  * @author Kyle Michel
  */
-public class Scalar extends Pio {
+public class Scalar extends Pio implements Serializable {
 
     /**
      * Set the exact value.
@@ -524,6 +529,36 @@ public class Scalar extends Pio {
         }
         return null;
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = 1864379853129479835L;
 
     /** Exact value. */
     private String value;

--- a/src/main/java/io/citrine/jpif/obj/common/Software.java
+++ b/src/main/java/io/citrine/jpif/obj/common/Software.java
@@ -3,6 +3,13 @@ package io.citrine.jpif.obj.common;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import io.citrine.jpif.util.PifSerializationUtil;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 
 /**
  * Information about a software package.
@@ -17,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
  * </ul>
  * @author Kyle Michel
  */
-public class Software extends Pio {
+public class Software extends Pio implements Serializable {
 
     /**
      * Set the name of the software package.
@@ -125,6 +132,36 @@ public class Software extends Pio {
         super.addUnsupportedField(key, value);
         return this;
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = 3894059382410712736L;
 
     /** Name of the software package. */
     private String name;

--- a/src/main/java/io/citrine/jpif/obj/common/Source.java
+++ b/src/main/java/io/citrine/jpif/obj/common/Source.java
@@ -8,9 +8,14 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import io.citrine.jpif.util.PifObjectMapper;
+import io.citrine.jpif.util.PifSerializationUtil;
 import org.apache.commons.validator.routines.UrlValidator;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 
 /**
  * Information about the source of a system.
@@ -24,7 +29,7 @@ import java.io.IOException;
  *
  * @author Kyle Michel
  */
-public class Source extends Pio {
+public class Source extends Pio implements Serializable {
 
     /**
      * Set the producer of this system.
@@ -111,6 +116,36 @@ public class Source extends Pio {
     private static boolean isUrl(final String source) {
         return (source != null) && UrlValidator.getInstance().isValid(source.trim());
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = 451087929374693919L;
 
     /** Producer of the system. */
     private String producer;

--- a/src/main/java/io/citrine/jpif/obj/common/Value.java
+++ b/src/main/java/io/citrine/jpif/obj/common/Value.java
@@ -11,8 +11,13 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.citrine.jpif.util.PifObjectMapper;
+import io.citrine.jpif.util.PifSerializationUtil;
 
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -31,7 +36,7 @@ import java.util.List;
  * </ul>
  * @author Kyle Michel
  */
-public class Value extends Pio {
+public class Value extends Pio implements Serializable {
 
     /**
      * Set the name of this value.
@@ -724,6 +729,36 @@ public class Value extends Pio {
         }
         return scalarMatrix;
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = 7089032030143869727L;
 
     /** String with the name of the value. */
     private String name;

--- a/src/main/java/io/citrine/jpif/obj/system/System.java
+++ b/src/main/java/io/citrine/jpif/obj/system/System.java
@@ -22,7 +22,13 @@ import io.citrine.jpif.obj.common.Source;
 import io.citrine.jpif.obj.merge.MergeStrategy;
 import io.citrine.jpif.obj.merge.PioReflection;
 import io.citrine.jpif.obj.system.chemical.ChemicalSystem;
+import io.citrine.jpif.util.PifSerializationUtil;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -57,7 +63,7 @@ import java.util.List;
         @JsonSubTypes.Type(value = ChemicalSystem.class),
         @JsonSubTypes.Type(name = "system.chemical.alloy", value = ChemicalSystem.class),  // Legacy support
         @JsonSubTypes.Type(name = "system.chemical.alloy.phase", value = ChemicalSystem.class)})  // Legacy support
-public class System extends Rcl {
+public class System extends Rcl implements Serializable {
 
     /**
      * Set the unique ID for this system.
@@ -829,15 +835,43 @@ public class System extends Rcl {
                                 fixedFieldName,
                                 fromReflection.getMethod("get" + fieldName).invoke(mergeFrom)
                         );
-                    } catch (IllegalAccessException e) {
-                        e.printStackTrace();
-                    } catch (InvocationTargetException e) {
+                    } catch (IllegalAccessException | InvocationTargetException e) {
                         e.printStackTrace();
                     }
                 });
 
         return mergeResult;
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = 8264725922709755726L;
 
     /** Permanent ID for this system. */
     private String uid;

--- a/src/main/java/io/citrine/jpif/obj/system/chemical/ChemicalSystem.java
+++ b/src/main/java/io/citrine/jpif/obj/system/chemical/ChemicalSystem.java
@@ -19,7 +19,13 @@ import io.citrine.jpif.obj.common.Source;
 import io.citrine.jpif.obj.merge.MergeStrategy;
 import io.citrine.jpif.obj.system.System;
 import io.citrine.jpif.obj.system.chemical.common.Composition;
+import io.citrine.jpif.util.PifSerializationUtil;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -49,7 +55,7 @@ import java.util.List;
  * @author Kyle Michel
  */
 @JsonTypeName("system.chemical")
-public class ChemicalSystem extends System {
+public class ChemicalSystem extends System implements Serializable {
 
     /**
      * Set the chemical formula for this system.
@@ -334,6 +340,36 @@ public class ChemicalSystem extends System {
     public ChemicalSystem merge(Pio mergeFrom, MergeStrategy strategy, List<String> ignoredFields) throws Exception {
         return (ChemicalSystem) super.merge(mergeFrom, strategy, ignoredFields);
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = -240125429691780502L;
 
     /** Chemical formula. */
     private String chemicalFormula;

--- a/src/main/java/io/citrine/jpif/obj/system/chemical/common/Composition.java
+++ b/src/main/java/io/citrine/jpif/obj/system/chemical/common/Composition.java
@@ -7,6 +7,13 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.citrine.jpif.obj.common.Pio;
 import io.citrine.jpif.obj.common.Scalar;
+import io.citrine.jpif.util.PifSerializationUtil;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
 
 /**
  * Information about an element in a composition vector using weight or atomic percents.
@@ -23,7 +30,7 @@ import io.citrine.jpif.obj.common.Scalar;
  *
  * @author Kyle Michel
  */
-public class Composition extends Pio {
+public class Composition extends Pio implements Serializable {
 
     /**
      * Set the element of the composition.
@@ -267,6 +274,36 @@ public class Composition extends Pio {
         super.addUnsupportedField(key, value);
         return this;
     }
+
+    /**
+     * Write this object to the output output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @throws IOException if this object cannot be written.
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        PifSerializationUtil.write(out, this);
+    }
+
+    /**
+     * Read into this object from the input stream.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @throws IOException if thrown while reading the stream.
+     * @throws ClassNotFoundException if thrown while reading the stream.
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        PifSerializationUtil.read(in, this);
+    }
+
+    /**
+     * Read an object with no data.
+     *
+     * @throws ObjectStreamException if thrown while reading the stream.
+     */
+    private void readObjectNoData() throws ObjectStreamException {}
+
+    private static final long serialVersionUID = 1164305075479090343L;
 
     /** Element this composition represents. */
     private String element;

--- a/src/main/java/io/citrine/jpif/util/PifSerializationUtil.java
+++ b/src/main/java/io/citrine/jpif/util/PifSerializationUtil.java
@@ -1,0 +1,41 @@
+package io.citrine.jpif.util;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Utilities for serialization and deserialization.
+ *
+ * @author Kyle Michel
+ */
+public class PifSerializationUtil {
+
+    /**
+     * Write the input object to the input output stream.
+     *
+     * @param out {@link ObjectOutputStream} to write to.
+     * @param object Object to write.
+     * @throws IOException if thrown while writing the object.
+     */
+    public static void write(final ObjectOutputStream out, final Object object) throws IOException {
+        out.writeObject(PifObjectMapper.getInstance().writeValueAsBytes(object));
+    }
+
+    /**
+     * Read from the input stream to the input object.
+     *
+     * @param in {@link ObjectInputStream} to read from.
+     * @param object Object to read to.
+     * @throws ClassNotFoundException if the class cannot be created.
+     * @throws IOException if thrown while reading the stream.
+     */
+    public static void read(final ObjectInputStream in, final Object object)
+            throws ClassNotFoundException, IOException {
+        final byte[] inputStreamBytes = (byte[]) in.readObject();
+        PifObjectMapper.getInstance().readerForUpdating(object).readValue(inputStreamBytes);
+    }
+
+    // Make sure that objects of this class cannot be instantiated
+    private PifSerializationUtil() {}
+}

--- a/src/test/java/io/citrine/jpif/obj/system/SystemTest.java
+++ b/src/test/java/io/citrine/jpif/obj/system/SystemTest.java
@@ -1,0 +1,49 @@
+package io.citrine.jpif.obj.system;
+
+import io.citrine.jpif.obj.common.Property;
+import io.citrine.jpif.obj.common.Scalar;
+import org.apache.commons.lang.SerializationUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link System} objects.
+ *
+ * @author Kyle Michel
+ */
+public class SystemTest {
+
+    @Test
+    public void testSerialization() throws Exception {
+
+        // Create the object to test
+        final System original = new System()
+                .addName("A")
+                .addProperty(new Property()
+                        .setName("B")
+                        .addVector(new Integer[]{1, 2, 3})
+                        .setUnits("C"));
+
+        // Make a deep copy of the object. This uses java serialization under the hood.
+        final System copy = (System) SerializationUtils.clone(original);
+
+        // Check that the results are equal
+        Assert.assertEquals(original.getName(0), copy.getName(0));
+        Assert.assertEquals(original.getProperty(0).getName(), copy.getProperty(0).getName());
+        Assert.assertEquals(original.getProperty(0).getUnits(), copy.getProperty(0).getUnits());
+        checkArrays(original.getProperty(0).getVector(0), copy.getProperty(0).getVector(0));
+    }
+
+    /**
+     * Check that the values of the to input arrays are the same.
+     *
+     * @param lhs First vector to check.
+     * @param rhs Second vector to check.
+     */
+    private void checkArrays(final Scalar[] lhs, final Scalar[] rhs) {
+        Assert.assertEquals(lhs.length, rhs.length);
+        for (int i = 0; i < lhs.length; ++i) {
+            Assert.assertEquals(lhs[i].toString(), rhs[i].toString());
+        }
+    }
+}


### PR DESCRIPTION
This adds the Serializable interface to all PIF system objects. The implementation uses JSON serialization to the two methods should be consistant.