### PR TITLE
Jackson Databind Vulnerability patch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <jackson.version>[2.8.9]</jackson.version>
+        <jackson.version>[2.8.11, 2.9.0)</jackson.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.citrine</groupId>
     <artifactId>jpif</artifactId>
-    <version>2.5.0</version>
+    <version>2.6.0</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
- The actual requirement was to upgrade to `>=2.8.11.1` not `2.8.9` (The first emails were incorrect)
